### PR TITLE
scraper/*/run.sh: do not redirect STDERR, guard against failure

### DIFF
--- a/scraper/cssinfos/run.sh
+++ b/scraper/cssinfos/run.sh
@@ -1,4 +1,6 @@
-node index.js > index.txt 2>&1
+#!/bin/bash
+
+node index.js > index.txt &&
 while read line; do
-    node page.js $line 2>&1;
+    node page.js $line
 done < index.txt

--- a/scraper/mdn/run.sh
+++ b/scraper/mdn/run.sh
@@ -1,4 +1,6 @@
-node index.js > index.txt 2>&1
+#!/bin/bash
+
+node index.js > index.txt &&
 while read line; do
-    node page.js $line 2>&1;
+    node page.js $line
 done < index.txt


### PR DESCRIPTION
The first STDERR redirect caused warnings to show up in index.txt, the
second one did not do anything.
