### PR TITLE
Draw topnav even when the user navigates to #css or #css/.

### DIFF
--- a/static/js/router.js
+++ b/static/js/router.js
@@ -131,7 +131,9 @@ define([
           }
         };
         _.bindAll(cb, 'fn');
-        this.route(languageName + '/:query', languageName, cb.fn);
+        // match #languageName/:query or #languageName/ or just #languageName
+        this.route(new RegExp("^" + languageName + '(?:/([^/])?)?$'),
+            languageName, cb.fn);
       }
     },
 


### PR DESCRIPTION
This should address #16.

When the user loads dochub.io, the location is updated to #css/. If the
user then refreshed, previously there was no route to #css/ so the
topnav was never rendered and the homepage never appeared to finish
loading. With this change, the #css/:query route is more forgiving so it
will handle #css/ and #css.
