### PR TITLE
The horizontal scroll is still visible on the ul#toc-results element

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -172,7 +172,7 @@
             <div id="search-header">
               <input class="input focused" id="search-box" name="search" type="text" autocomplete="off">
             </div>
-            <ul class="nav nav-list" id="toc-results" style="overflow-y: scroll">
+            <ul class="nav nav-list" id="toc-results" style="overflow-y: scroll; overflow-x: hidden;">
             </ul>
           </div>
         </div>


### PR DESCRIPTION
...#toc-results

screenshot: http://i.imgur.com/YK1E8.png

By adding overflow-x: hidden on it, it will stay hidden now
