### PR TITLE
Condense search window when there are fewer results

### DIFF
--- a/static/js/views/fullwindow.js
+++ b/static/js/views/fullwindow.js
@@ -21,16 +21,16 @@ define([
     onResize: function() {
       // make sure the TOC div reaches the bottom of the screen
       var windowHeight = $(window).height();
-      this.$tocWell.height(windowHeight - 100);
+      this.$tocWell.css('max-height', windowHeight - 100 + 'px');
 
       // Adjust the -196 magic # to account for the heights of new objects
       // put in the tocbar. For example, if a new thing occupies +24px height
       // in the toc bar, make the magic number -(196 + 24) = -220.
-      this.$tocResultsDiv.height(windowHeight - 125);
+      this.$tocResultsDiv.css('max-height', windowHeight - 125 + 'px');
 
       this.$searchResults.height(windowHeight - 80);
       this.$container.height(Math.max($('#toc').height(), this.$searchResults.height()));
-    },
+    }
   });
 
   return FullWindowView;


### PR DESCRIPTION
Currently the search window in condensed view (narrower than 700px or so) takes
up the entire height of the page, making it very difficult to scroll past as
scrollbars are nested inside of each other. By changing the height to
maxHeight, the search window will only take up the full page if there is more
than a full page of search results. As the user filters the search options, the
search window will shrink as well, displaying the results "above the fold".

Screenshot: https://skitch.com/kburke/en32p/dochub-instant-documentation-search
