### PR TITLE
Remove bottom scrollbar

### DIFF
--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -24,6 +24,11 @@ div#about table tr td.desc {
   vertical-align: middle;
 }
 
+/* twitter bootstrap default is 1px too short */
+.nav-list {
+    padding-right: 15px;
+}
+
 p.source-link {
   border-width: 1px;
   border-color: #888;


### PR DESCRIPTION
Currently the bottom scrollbar in the left-hand TOC is always present, even
when the content does not nearly reach the width of the TOC.

screenshot: https://skitch.com/kburke/en37s/dochub-instant-documentation-search

This adds one extra pixel of padding (from 14px to 15px), shrinking the box
width by 1px so that the scrollbar goes away.
