### PR TITLE
Start dochub with `npm start`

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Run the server:
 
     npm install # downloads dependencies for web server
-    node web.js
+    npm start
 
 Open http://localhost:5000/ in your browser.
 

--- a/package.json
+++ b/package.json
@@ -5,5 +5,8 @@
     "requirejs": "1.0.x"
     , "express": "2.5.x"
     , "underscore": "1.3.x"
+  },
+  "scripts": {
+    "start": "node web.js"
   }
 }


### PR DESCRIPTION
Use the built-in `start` command of npm to start dochub.
